### PR TITLE
fix(db): remove default value for user ID and create user insert policy

### DIFF
--- a/packages/db/prisma/migrations/20250609073928_remove_default_user_id_init/migration.sql
+++ b/packages/db/prisma/migrations/20250609073928_remove_default_user_id_init/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "users" ALTER COLUMN "id" DROP DEFAULT;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -16,7 +16,7 @@ datasource db {
 }
 
 model User {
-  id         String  @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  id         String  @id @db.Uuid // no @default(dbgenerated("gen_random_uuid()")), should link to the user registered
   email      String  @unique
   first_name String?
   last_name  String?

--- a/packages/db/supabase/rls/01_policies_users.sql
+++ b/packages/db/supabase/rls/01_policies_users.sql
@@ -4,3 +4,7 @@ CREATE POLICY "User can access their own record" ON users
     FOR ALL
     USING (id = (SELECT auth.uid()))
     WITH CHECK (id = (SELECT auth.uid()));
+
+CREATE POLICY "Anyone can create a user" ON users
+    FOR INSERT
+    WITH CHECK (true);


### PR DESCRIPTION
- Removed the default generation of user ID in the Prisma schema to ensure it links to the registered user.
- Added a migration to drop the default value for the user ID column in the database.
- Introduced a new policy allowing anyone to create a user in the Supabase RLS configuration.