### PR TITLE
Fix CI step for lockfile check

### DIFF
--- a/.github/workflows/check-lockfile.yml
+++ b/.github/workflows/check-lockfile.yml
@@ -26,6 +26,6 @@ jobs:
           cache: 'pnpm'
 
       - name: Check for peer dependency warnings
-        run:
-          pnpm install --frozen-lockfile --strict-peer-dependencies |
+        run: |
+          pnpm install --frozen-lockfile --strict-peer-dependencies
           pnpm add -D eslint -w


### PR DESCRIPTION
## Summary
- fix GitHub Actions step to properly run two commands

## Testing
- `pnpm install --frozen-lockfile --strict-peer-dependencies`


------
https://chatgpt.com/codex/tasks/task_e_684aa1003d28832ca2b73ceff50b8467